### PR TITLE
remove assignment to assert variable

### DIFF
--- a/test/fixtures/separated/expected.js
+++ b/test/fixtures/separated/expected.js
@@ -1,0 +1,4 @@
+var assert;
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/separated/fixture.js
+++ b/test/fixtures/separated/fixture.js
@@ -1,0 +1,9 @@
+var assert;
+assert = require('assert');
+function add (a, b) {
+    console.assert(typeof a === 'number');
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/separated_singlevar/expected.js
+++ b/test/fixtures/separated_singlevar/expected.js
@@ -1,0 +1,4 @@
+var add, assert;
+add = function (a, b) {
+    return a + b;
+};

--- a/test/fixtures/separated_singlevar/fixture.js
+++ b/test/fixtures/separated_singlevar/fixture.js
@@ -1,0 +1,9 @@
+var add, assert;
+assert = require('assert');
+add = function (a, b) {
+    console.assert(typeof a === 'number');
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -26,4 +26,6 @@ describe('unassert', function () {
     testTransform('commonjs');
     testTransform('commonjs_singlevar');
     testTransform('commonjs_powerassert');
+    testTransform('separated');
+    testTransform('separated_singlevar');
 });


### PR DESCRIPTION
Support removal of assignment to assert variable.
(For example, CoffeeScript produces this style of assinment)
On the other hand, do not remove VariableDeclarator since there are too many assumptions to make.

before:
```javascript
var assert;
assert = require('assert');
function add (a, b) {
    console.assert(typeof a === 'number');
    assert(!isNaN(a));
    assert.equal(typeof b, 'number');
    assert.ok(!isNaN(b));
    return a + b;
}
```

after:
```javascript
var assert;
function add(a, b) {
    return a + b;
}
```
