### PR TITLE
Support removal of ES6 import declaration

### DIFF
--- a/test/fixtures/es6module/expected.js
+++ b/test/fixtures/es6module/expected.js
@@ -1,5 +1,4 @@
 'use strict';
-
 function add(a, b) {
     return a + b;
 }

--- a/test/fixtures/es6module/expected.js
+++ b/test/fixtures/es6module/expected.js
@@ -1,4 +1,3 @@
-'use strict';
 function add(a, b) {
     return a + b;
 }

--- a/test/fixtures/es6module/expected.js
+++ b/test/fixtures/es6module/expected.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/es6module/fixture.js
+++ b/test/fixtures/es6module/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import assert from 'assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/es6module/fixture.js
+++ b/test/fixtures/es6module/fixture.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import assert from 'assert';
 
 function add (a, b) {

--- a/test/fixtures/es6module_powerassert/expected.js
+++ b/test/fixtures/es6module_powerassert/expected.js
@@ -1,5 +1,4 @@
 'use strict';
-
 function add(a, b) {
     return a + b;
 }

--- a/test/fixtures/es6module_powerassert/expected.js
+++ b/test/fixtures/es6module_powerassert/expected.js
@@ -1,4 +1,3 @@
-'use strict';
 function add(a, b) {
     return a + b;
 }

--- a/test/fixtures/es6module_powerassert/expected.js
+++ b/test/fixtures/es6module_powerassert/expected.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/es6module_powerassert/fixture.js
+++ b/test/fixtures/es6module_powerassert/fixture.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import assert from 'power-assert';
 
 function add (a, b) {

--- a/test/fixtures/es6module_powerassert/fixture.js
+++ b/test/fixtures/es6module_powerassert/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import assert from 'power-assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ function testTransform (fixtureName, extraOptions) {
     it(fixtureName, function () {
         var fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
         var expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
-        var ast = esprima.parse(fs.readFileSync(fixtureFilepath));
+        var ast = esprima.parse(fs.readFileSync(fixtureFilepath),  { sourceType: 'module' });
         // console.log(JSON.stringify(ast, null, 2));
         var modifiedAst = unassert(ast);
         var actual = escodegen.generate(modifiedAst);
@@ -28,4 +28,6 @@ describe('unassert', function () {
     testTransform('commonjs_powerassert');
     testTransform('assignment');
     testTransform('assignment_singlevar');
+    testTransform('es6module');
+    testTransform('es6module_powerassert');
 });


### PR DESCRIPTION
Support removal of ES6 import declaration.

before:

```js
import assert from 'assert';

function add (a, b) {
    assert(!isNaN(a));
    assert.equal(typeof b, 'number');
    assert.ok(!isNaN(b));
    return a + b;
}
```

after:
```js
function add(a, b) {
    return a + b;
}
```
