### PR TITLE
Support ImportNamespaceSpecifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ unassert also removes assert variable declarations,
 * `var assert = require("power-assert")`
 * `import assert from "assert"`
 * `import assert from "power-assert"`
+* `import * as assert from "assert"`
+* `import * as assert from "power-assert"`
 
 and assignments.
 

--- a/index.js
+++ b/index.js
@@ -37,8 +37,10 @@ var matchers = patterns.map(escallmatch);
 
 var declarationPatterns = [
     'import assert from "assert"',
+    'import * as assert from "assert"',
     'var assert = require("assert")',
     'import assert from "power-assert"',
+    'import * as assert from "power-assert"',
     'var assert = require("power-assert")'
 ];
 var declarationMatchers = [];

--- a/test/fixtures/es6module_namespece/expected.js
+++ b/test/fixtures/es6module_namespece/expected.js
@@ -1,0 +1,3 @@
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/es6module_namespece/fixture.js
+++ b/test/fixtures/es6module_namespece/fixture.js
@@ -1,0 +1,8 @@
+import * as assert from 'assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -30,5 +30,6 @@ describe('unassert', function () {
     testTransform('assignment_singlevar');
     testTransform('es6module');
     testTransform('es6module_powerassert');
+    testTransform('es6module_namespece');
     testTransform('not_an_expression_statement');
 });


### PR DESCRIPTION
before:
```js
import * as assert from 'assert';

function add (a, b) {
    assert(!isNaN(a));
    assert.equal(typeof b, 'number');
    assert.ok(!isNaN(b));
    return a + b;
}
```

after:
```js
function add(a, b) {
    return a + b;
}
```
