### PR TITLE
Add empty block if parent is non-block statement

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "escallmatch": "^1.4.1",
     "esprima": "^2.5.0",
     "espurify": "^1.3.0",
-    "estraverse": "^4.1.0"
+    "estraverse": "^4.1.0",
+    "esutils": "^2.0.2"
   },
   "devDependencies": {
     "escodegen": "^1.7.0",

--- a/test/fixtures/non_block_statement/expected.js
+++ b/test/fixtures/non_block_statement/expected.js
@@ -1,0 +1,12 @@
+'use strict';
+function add(a, b) {
+    if (!isNaN(a)) {
+    }
+    if (typeof b === 'number') {
+    }
+    if (typeof a === 'number') {
+    } else if (typeof b === 'number') {
+    } else {
+    }
+    return a + b;
+}

--- a/test/fixtures/non_block_statement/fixture.js
+++ b/test/fixtures/non_block_statement/fixture.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var assert = require('assert');
+
+function add (a, b) {
+    if (!isNaN(a)) assert(0 < a);
+    if (typeof b === 'number') {
+        assert(0 < b);
+    }
+
+    if (typeof a === 'number')
+        assert(0 < a);
+    else if (typeof b === 'number')
+        assert(0 < b);
+    else
+        assert(false);
+
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -32,4 +32,5 @@ describe('unassert', function () {
     testTransform('es6module_powerassert');
     testTransform('es6module_namespece');
     testTransform('not_an_expression_statement');
+    testTransform('non_block_statement');
 });


### PR DESCRIPTION
Dealing with IfStatement without curly braces.

refs twada/unassert#7

```js
'use strict';

var assert = require('assert');

function add (a, b) {
    if (!isNaN(a)) assert(0 < a);
    if (typeof b === 'number') {
        assert(0 < b);
    }

    if (typeof a === 'number')
        assert(0 < a);
    else if (typeof b === 'number')
        assert(0 < b);
    else
        assert(false);

    return a + b;
}
```

becomes

```js
'use strict';
function add(a, b) {
    if (!isNaN(a)) {
    }
    if (typeof b === 'number') {
    }
    if (typeof a === 'number') {
    } else if (typeof b === 'number') {
    } else {
    }
    return a + b;
}
```
